### PR TITLE
Imo interface

### DIFF
--- a/litebirdtask/scripts/hardware_from_imo.py
+++ b/litebirdtask/scripts/hardware_from_imo.py
@@ -10,62 +10,62 @@ import numpy as np
 import toml
 
 wnp = {
-            "LF1": 9,
-            "LF2": 36,
-            "MF1": 61,
-            "MF2": 61,
-            "HF1": 127,
-            "HF2": 127,
-            "HF3": 169,
-        }
+    "LF1": 9,
+    "LF2": 36,
+    "MF1": 61,
+    "MF2": 61,
+    "HF1": 127,
+    "HF2": 127,
+    "HF3": 169,
+}
 
 pix2w = {
-            "LF1": ["LP1", "LP2"],
-            "LF2": ["LP3", "LP4"],
-            "MF1": ["MP1"],
-            "MF2": ["MP2"],
-            "HF1": ["HP1"],
-            "HF2": ["HP2"],
-            "HF3": ["HP3"],
-        }
+    "LF1": ["LP1", "LP2"],
+    "LF2": ["LP3", "LP4"],
+    "MF1": ["MP1"],
+    "MF2": ["MP2"],
+    "HF1": ["HP1"],
+    "HF2": ["HP2"],
+    "HF3": ["HP3"],
+}
 
-toast_keys = ['pixels', 'bands', 'telescopes', 'wafers', 'detectors']
+toast_keys = ["pixels", "bands", "telescopes", "wafers", "detectors"]
 pixmm = {
-            "LP1": 32.0,
-            "LP2": 32.0,
-            "LP3": 16.0,
-            "LP4": 16.0,
-            "MP1": 11.6,
-            "MP2": 11.6,
-            "HP1": 6.6,
-            "HP2": 6.6,
-            "HP3": 5.7,
-        }
+    "LP1": 32.0,
+    "LP2": 32.0,
+    "LP3": 16.0,
+    "LP4": 16.0,
+    "MP1": 11.6,
+    "MP2": 11.6,
+    "HP1": 6.6,
+    "HP2": 6.6,
+    "HP3": 5.7,
+}
 pbd = {
-            "LP1": ["L1-040", "L1-060", "L1-078"],
-            "LP2": ["L2-050", "L2-068", "L2-089"],
-            "LP3": ["L3-068", "L3-089", "L3-119"],
-            "LP4": ["L4-078", "L4-100", "L4-140"],
-            "MP1": ["M1-100", "M1-140", "M1-195"],
-            "MP2": ["M2-119", "M2-166"],
-            "HP1": ["H1-195", "H1-280"],
-            "HP2": ["H2-235", "H2-337"],
-            "HP3": ["H3-402"],
-        }
+    "LP1": ["L1-040", "L1-060", "L1-078"],
+    "LP2": ["L2-050", "L2-068", "L2-089"],
+    "LP3": ["L3-068", "L3-089", "L3-119"],
+    "LP4": ["L4-078", "L4-100", "L4-140"],
+    "MP1": ["M1-100", "M1-140", "M1-195"],
+    "MP2": ["M2-119", "M2-166"],
+    "HP1": ["H1-195", "H1-280"],
+    "HP2": ["H2-235", "H2-337"],
+    "HP3": ["H3-402"],
+}
 
-def get_wafer_dic (tele):
 
+def get_wafer_dic(tele):
 
     windx = 0
-    wafers={}
-    wf =  {}
+    wafers = {}
+    wf = {}
 
-    if tele[0]== "L":
+    if tele[0] == "L":
         for wt, wnum, hd in zip(
-                ["LF1", "LF2", "LF2", "LF1", "LF1", "LF2", "LF2", "LF1"],
-                [0, 1, 2, 3, 4, 5, 6, 7],
-                [0, 0, 1, 1, 1, 1, 0, 0],
-            ):
+            ["LF1", "LF2", "LF2", "LF1", "LF1", "LF2", "LF2", "LF1"],
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [0, 0, 1, 1, 1, 1, 0, 0],
+        ):
             wn = "L{:02d}".format(wnum)
             wf["type"] = wt
             wf["npixel"] = wnp[wt]
@@ -76,19 +76,19 @@ def get_wafer_dic (tele):
             wafers[wn] = wf
             windx += 1
 
-    elif tele[0]== "M":
+    elif tele[0] == "M":
         for wt, wnum in zip(
-                ["MF1", "MF2", "MF2", "MF1", "MF2", "MF2", "MF1"], [3, 1, 0, 2, 5, 6, 4]
-            ):
-                wn = "M{:02d}".format(wnum)
-                wf["type"] = wt
-                wf["npixel"] = wnp[wt]
-                wf["pixels"] = pix2w[wt]
-                wf["position"] = windx
-                wf["telescope"] = "MFT"
-                wafers[wn] = wf
-                windx += 1
-    elif tele[0] =="H":
+            ["MF1", "MF2", "MF2", "MF1", "MF2", "MF2", "MF1"], [3, 1, 0, 2, 5, 6, 4]
+        ):
+            wn = "M{:02d}".format(wnum)
+            wf["type"] = wt
+            wf["npixel"] = wnp[wt]
+            wf["pixels"] = pix2w[wt]
+            wf["position"] = windx
+            wf["telescope"] = "MFT"
+            wafers[wn] = wf
+            windx += 1
+    elif tele[0] == "H":
         for wt, wnum in zip(["HF1", "HF2", "HF3"], [0, 1, 2]):
             wn = "H{:02d}".format(wnum)
             wf["type"] = wt
@@ -102,94 +102,95 @@ def get_wafer_dic (tele):
     return wafers
 
 
-
 def main():
     parser = argparse.ArgumentParser(
         description="This program reads the IMO `json` file downloaded from the \
         Instrument MOdel repo and makes it compatible with toast3 focalplane.\
         It produces hardware file per frequency channel. ",
-
         usage="lbt_hardware_from_imo  ",
     )
     parser.add_argument(
-    "--hardware", required=True, default=None, help="Input json file"
+        "--hardware", required=True, default=None, help="Input json file"
     )
     parser.add_argument(
-            "--output-directory",
-            required=False,
-            default="./",
-            help="path to the output directory",
-        )
+        "--output-directory",
+        required=False,
+        default="./",
+        help="path to the output directory",
+    )
     args = parser.parse_args()
 
     print("Loading hardware file {}...".format(args.hardware), flush=True)
     with open(args.hardware) as json_file:
         data = json.load(json_file)
 
-
     # Loop over the entries of json file, populating the new dictionary per freq. channel
 
-    for i in range(len(data ['data_files']) ) :
+    for i in range(len(data["data_files"])):
 
-        if data['data_files'][i]['name'] == "instrument_info":
-            instrument_dic = data['data_files'][i]['metadata']
-            toast_wf =get_wafer_dic( instrument_dic['name'])
+        if data["data_files"][i]["name"] == "instrument_info":
+            instrument_dic = data["data_files"][i]["metadata"]
+            toast_wf = get_wafer_dic(instrument_dic["name"])
             continue
-        elif data['data_files'][i]['name'] == "channel_info":
+        elif data["data_files"][i]["name"] == "channel_info":
 
-            channel_dic =data['data_files'][i] ['metadata']
-            newhw={k:{}  for k in toast_keys }
-            iold =i
+            channel_dic = data["data_files"][i]["metadata"]
+            newhw = {k: {} for k in toast_keys}
+            iold = i
             continue
-        elif data['data_files'][i]['name'] == "detector_info" :
-            det_dic=(data['data_files'][i] ['metadata']  )
+        elif data["data_files"][i]["name"] == "detector_info":
+            det_dic = data["data_files"][i]["metadata"]
         else:
             break
 
-        newhw ['telescopes']  [ instrument_dic['name'] ] ={'wafers' : instrument_dic['wafers'],
-                                                          'platescale':instrument_dic['platescale_deg_mm'],
-                                                          'waferspace' : instrument_dic['waferspace_mm']
-                                                              }
-        newhw ['pixels']   [det_dic['pixtype']]=  {
-                                                 'bands' :pbd[det_dic['pixtype']] ,
-                                                'sizemm':pixmm[det_dic['pixtype']]
-                                                }
+        newhw["telescopes"][instrument_dic["name"]] = {
+            "wafers": instrument_dic["wafers"],
+            "platescale": instrument_dic["platescale_deg_mm"],
+            "waferspace": instrument_dic["waferspace_mm"],
+        }
+        newhw["pixels"][det_dic["pixtype"]] = {
+            "bands": pbd[det_dic["pixtype"]],
+            "sizemm": pixmm[det_dic["pixtype"]],
+        }
 
+        newhw["wafers"][det_dic["wafer"]] = {
+            "type": toast_wf[det_dic["wafer"]]["type"],
+            "npixel": np.int_(channel_dic["number_of_detectors"] / 2),
+            "pixels": [det_dic["pixtype"]],
+            "position": toast_wf[det_dic["wafer"]]["position"],
+            "telescope": instrument_dic["name"],
+        }
 
-        newhw ['wafers'][det_dic['wafer']] =   {
-                                            'type':toast_wf[det_dic['wafer']]['type'],
-                                            'npixel':np.int_(channel_dic['number_of_detectors']/2),
-                                            'pixels':[det_dic['pixtype']],
-                                            'position':toast_wf[det_dic['wafer']]['position'],
-                                            'telescope': instrument_dic['name']
-                                             }
+        newhw["bands"][channel_dic["channel"]] = {
+            "center": channel_dic["bandcenter_ghz"],
+            "bandwidth": channel_dic["bandwidth_ghz"],
+            "bandpass": "",
+            "NET": channel_dic["net_detector_ukrts"],
+            "fwhm": channel_dic["fwhm_arcmin"],
+            "fknee": channel_dic["fknee_mhz"],
+            "fmin": channel_dic["fmin_hz"],
+            "alpha": channel_dic["alpha"],
+        }
 
-        newhw ['bands'] [ channel_dic['channel']]= {
-            'center': channel_dic['bandcenter_ghz'],
-            'bandwidth': channel_dic['bandwidth_ghz'],
-            'bandpass':'',
-            'NET': channel_dic['net_detector_ukrts'],
-            'fwhm': channel_dic['fwhm_arcmin'],
-            'fknee': channel_dic['fknee_mhz'],
-            'fmin': channel_dic['fmin_hz'],
-            'alpha': channel_dic['alpha']}
-
-
-        newhw['detectors'][det_dic['name']] = { 'wafer': det_dic['wafer'],
-                              'pixel': f"{det_dic['pixel']:03d}",
-                              'pixtype':det_dic[ "pixtype" ],
-                              'band': det_dic[ "channel"],
-                              'fwhm': det_dic[ "fwhm_arcmin"],
-                              'pol':det_dic[ "pol" ],
-                              'orient':det_dic[ "orient" ],
-                              'quat':det_dic[ "quat" ],
-                              'UID':data['data_files'][i]['uuid']
-                             }
-        if i - iold == channel_dic['number_of_detectors']:
-            print(f"Dumping {i-iold} detectors into {args.output_directory}/{channel_dic['channel']}.toml.gz"  )
-            with open( f"{args.output_directory}/{channel_dic['channel']}.toml.gz", "w") as f:
-                toml.dump( newhw, f)
-
+        newhw["detectors"][det_dic["name"]] = {
+            "wafer": det_dic["wafer"],
+            "pixel": f"{det_dic['pixel']:03d}",
+            "pixtype": det_dic["pixtype"],
+            "band": det_dic["channel"],
+            "fwhm": det_dic["fwhm_arcmin"],
+            "pol": det_dic["pol"],
+            "orient": det_dic["orient"],
+            "quat": det_dic["quat"],
+            "UID": data["data_files"][i]["uuid"],
+        }
+        if i - iold == channel_dic["number_of_detectors"]:
+            print(
+                f"Dumping {i-iold} detectors into {args.output_directory}/{channel_dic['channel']}.toml.gz"
+            )
+            with open(
+                f"{args.output_directory}/{channel_dic['channel']}.toml.gz", "w"
+            ) as f:
+                toml.dump(newhw, f)
 
     return
 

--- a/litebirdtask/scripts/hardware_from_imo.py
+++ b/litebirdtask/scripts/hardware_from_imo.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2015-2021 LiteBIRD Collaboration.
+# Full license can be found in the top level "LICENSE" file.
+"""
+Plot a hardware model.
+"""
+
+import argparse
+import json
+import numpy as np
+import toml
+
+def get_wafer_dic (tele):
+
+    wnp = {
+            "LF1": 9,
+            "LF2": 36,
+            "MF1": 61,
+            "MF2": 61,
+            "HF1": 127,
+            "HF2": 127,
+            "HF3": 169,
+        }
+
+    pix2w = {
+            "LF1": ["LP1", "LP2"],
+            "LF2": ["LP3", "LP4"],
+            "MF1": ["MP1"],
+            "MF2": ["MP2"],
+            "HF1": ["HP1"],
+            "HF2": ["HP2"],
+            "HF3": ["HP3"],
+        }
+
+    toast_keys = ['pixels', 'bands', 'telescopes', 'wafers', 'detectors']
+    pixmm = {
+            "LP1": 32.0,
+            "LP2": 32.0,
+            "LP3": 16.0,
+            "LP4": 16.0,
+            "MP1": 11.6,
+            "MP2": 11.6,
+            "HP1": 6.6,
+            "HP2": 6.6,
+            "HP3": 5.7,
+        }
+    pbd = {
+            "LP1": ["L1-040", "L1-060", "L1-078"],
+            "LP2": ["L2-050", "L2-068", "L2-089"],
+            "LP3": ["L3-068", "L3-089", "L3-119"],
+            "LP4": ["L4-078", "L4-100", "L4-140"],
+            "MP1": ["M1-100", "M1-140", "M1-195"],
+            "MP2": ["M2-119", "M2-166"],
+            "HP1": ["H1-195", "H1-280"],
+            "HP2": ["H2-235", "H2-337"],
+            "HP3": ["H3-402"],
+        }
+
+
+    windx = 0
+    wafers={}
+    wf =  {}
+
+    if tele[0]== "L":
+        for wt, wnum, hd in zip(
+                ["LF1", "LF2", "LF2", "LF1", "LF1", "LF2", "LF2", "LF1"],
+                [0, 1, 2, 3, 4, 5, 6, 7],
+                [0, 0, 1, 1, 1, 1, 0, 0],
+            ):
+            wn = "L{:02d}".format(wnum)
+            wf["type"] = wt
+            wf["npixel"] = wnp[wt]
+            wf["pixels"] = pix2w[wt]
+            wf["handed"] = hd
+            wf["position"] = windx
+            wf["telescope"] = "LFT"
+            wafers[wn] = wf
+            windx += 1
+
+    elif tele[0]== "M":
+        for wt, wnum in zip(
+                ["MF1", "MF2", "MF2", "MF1", "MF2", "MF2", "MF1"], [3, 1, 0, 2, 5, 6, 4]
+            ):
+                wn = "M{:02d}".format(wnum)
+                wf["type"] = wt
+                wf["npixel"] = wnp[wt]
+                wf["pixels"] = pix2w[wt]
+                wf["position"] = windx
+                wf["telescope"] = "MFT"
+                wafers[wn] = wf
+                windx += 1
+    elif tele[0] =="H":
+        for wt, wnum in zip(["HF1", "HF2", "HF3"], [0, 1, 2]):
+            wn = "H{:02d}".format(wnum)
+            wf["type"] = wt
+            # wf["rhombusgap"] = wrhombgap[wt]
+            wf["npixel"] = wnp[wt]
+            wf["pixels"] = pix2w[wt]
+            wf["position"] = windx
+            wf["telescope"] = "HFT"
+            wafers[wn] = wf
+            windx += 1
+    return wafers
+
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="This program reads the IMO `json` file downloaded from the \
+        Instrument MOdel repo and makes it compatible with toast3 focalplane.\
+        It produces hardware file per frequency channel. ",
+
+        usage="lbt_hardware_from_imo  ",
+    )
+    parser.add_argument(
+    "--hardware", required=True, default=None, help="Input json file"
+    )
+    args = parser.parse_args()
+
+    print("Loading hardware file {}...".format(file), flush=True)
+    with open(args.hardware) as json_file:
+        data = json.load(json_file)
+
+
+    # Loop over the entries of json file, populating the new dictionary per freq. channel
+
+    for i in range(len(data ['data_files']) ) :
+
+        if data['data_files'][i]['name'] == "instrument_info":
+            instrument_dic = data['data_files'][i]['metadata']
+            toast_wf =get_wafer_dic( instrument_dic['name'])
+            continue
+        elif data['data_files'][i]['name'] == "channel_info":
+
+            channel_dic =data['data_files'][i] ['metadata']
+            newhw={k:{}  for k in toast_keys }
+            iold =i
+            continue
+        elif data['data_files'][i]['name'] == "detector_info" :
+            det_dic=(data['data_files'][i] ['metadata']  )
+        else:
+            break
+
+        newhw ['telescopes']  [ instrument_dic['name'] ] ={'wafers' : instrument_dic['wafers'],
+                                                          'platescale':instrument_dic['platescale_deg_mm'],
+                                                          'waferspace' : instrument_dic['waferspace_mm']
+                                                              }
+        newhw ['pixels']   [det_dic['pixtype']]=  {
+                                                 'bands' :pbd[det_dic['pixtype']] ,
+                                                'sizemm':pixmm[det_dic['pixtype']]
+                                                }
+
+
+        newhw ['wafers'][det_dic['wafer']] =   {
+                                            'type':toast_wf[det_dic['wafer']]['type'],
+                                            'npixel':np.int_(channel_dic['number_of_detectors']/2),
+                                            'pixels':[det_dic['pixtype']],
+                                            'position':toast_wf[det_dic['wafer']]['position'],
+                                            'telescope': instrument_dic['name']
+                                             }
+
+        newhw ['bands'] [ channel_dic['channel']]= {
+            'center': channel_dic['bandcenter_ghz'],
+            'bandwidth': channel_dic['bandwidth_ghz'],
+            'bandpass':'',
+            'NET': channel_dic['net_detector_ukrts'],
+            'fwhm': channel_dic['fwhm_arcmin'],
+            'fknee': channel_dic['fknee_mhz'],
+            'fmin': channel_dic['fmin_hz'],
+            'alpha': channel_dic['alpha']}
+
+
+        newhw['detectors'][det_dic['name']] = { 'wafer': det_dic['wafer'],
+                              'pixel': f"{det_dic['pixel']:03d}",
+                              'pixtype':det_dic[ "pixtype" ],
+                              'band': det_dic[ "channel"],
+                              'fwhm': det_dic[ "fwhm_arcmin"],
+                              'pol':det_dic[ "pol" ],
+                              'orient':det_dic[ "orient" ],
+                              'quat':det_dic[ "quat" ],
+                              'UID':data['data_files'][i]['uuid']
+                             }
+        if i - iold == channel_dic['number_of_detectors']:
+            print(f"Dumping {i-iold} detectors into {channel_dic['channel']}.toml.gz"  )
+            with open( f"{channel_dic['channel']}.toml.gz", "w") as f:
+                toml.dump( newhw, f)
+
+            break 
+
+    return

--- a/litebirdtask/scripts/hardware_from_imo.py
+++ b/litebirdtask/scripts/hardware_from_imo.py
@@ -9,6 +9,10 @@ import json
 import numpy as np
 import toml
 
+
+#the following dictionaries are kept from the scripts in litebirdms. The quantities are hardcoded  allow backward compatibility, with previous IMO files.
+
+## number of pixels per wafer type 
 wnp = {
     "LF1": 9,
     "LF2": 36,
@@ -17,8 +21,8 @@ wnp = {
     "HF1": 127,
     "HF2": 127,
     "HF3": 169,
-}
-
+} 
+#associate each wafer type to a pixel-type 
 pix2w = {
     "LF1": ["LP1", "LP2"],
     "LF2": ["LP3", "LP4"],
@@ -30,6 +34,7 @@ pix2w = {
 }
 
 toast_keys = ["pixels", "bands", "telescopes", "wafers", "detectors"]
+#size in mm of each pixel-type 
 pixmm = {
     "LP1": 32.0,
     "LP2": 32.0,
@@ -41,6 +46,7 @@ pixmm = {
     "HP2": 6.6,
     "HP3": 5.7,
 }
+#associate each pixel-type to the trichroic,dichroic, monochroic frequency band 
 pbd = {
     "LP1": ["L1-040", "L1-060", "L1-078"],
     "LP2": ["L2-050", "L2-068", "L2-089"],

--- a/litebirdtask/scripts/hardware_from_imo.py
+++ b/litebirdtask/scripts/hardware_from_imo.py
@@ -9,9 +9,7 @@ import json
 import numpy as np
 import toml
 
-def get_wafer_dic (tele):
-
-    wnp = {
+wnp = {
             "LF1": 9,
             "LF2": 36,
             "MF1": 61,
@@ -21,7 +19,7 @@ def get_wafer_dic (tele):
             "HF3": 169,
         }
 
-    pix2w = {
+pix2w = {
             "LF1": ["LP1", "LP2"],
             "LF2": ["LP3", "LP4"],
             "MF1": ["MP1"],
@@ -31,8 +29,8 @@ def get_wafer_dic (tele):
             "HF3": ["HP3"],
         }
 
-    toast_keys = ['pixels', 'bands', 'telescopes', 'wafers', 'detectors']
-    pixmm = {
+toast_keys = ['pixels', 'bands', 'telescopes', 'wafers', 'detectors']
+pixmm = {
             "LP1": 32.0,
             "LP2": 32.0,
             "LP3": 16.0,
@@ -43,7 +41,7 @@ def get_wafer_dic (tele):
             "HP2": 6.6,
             "HP3": 5.7,
         }
-    pbd = {
+pbd = {
             "LP1": ["L1-040", "L1-060", "L1-078"],
             "LP2": ["L2-050", "L2-068", "L2-089"],
             "LP3": ["L3-068", "L3-089", "L3-119"],
@@ -54,6 +52,8 @@ def get_wafer_dic (tele):
             "HP2": ["H2-235", "H2-337"],
             "HP3": ["H3-402"],
         }
+
+def get_wafer_dic (tele):
 
 
     windx = 0
@@ -114,9 +114,15 @@ def main():
     parser.add_argument(
     "--hardware", required=True, default=None, help="Input json file"
     )
+    parser.add_argument(
+            "--output-directory",
+            required=False,
+            default="./",
+            help="path to the output directory",
+        )
     args = parser.parse_args()
 
-    print("Loading hardware file {}...".format(file), flush=True)
+    print("Loading hardware file {}...".format(args.hardware), flush=True)
     with open(args.hardware) as json_file:
         data = json.load(json_file)
 
@@ -180,10 +186,12 @@ def main():
                               'UID':data['data_files'][i]['uuid']
                              }
         if i - iold == channel_dic['number_of_detectors']:
-            print(f"Dumping {i-iold} detectors into {channel_dic['channel']}.toml.gz"  )
-            with open( f"{channel_dic['channel']}.toml.gz", "w") as f:
+            print(f"Dumping {i-iold} detectors into {args.output_directory}/{channel_dic['channel']}.toml.gz"  )
+            with open( f"{args.output_directory}/{channel_dic['channel']}.toml.gz", "w") as f:
                 toml.dump( newhw, f)
 
-            break 
 
     return
+
+
+main()


### PR DESCRIPTION
 Implement an interface in `litebirdtask`  aimed at reading the Instrument MOdel files  that are currently produced by the LiteBIRD IMO team. 
there are some quantities that are inherited from the previous IMO files produced by `litebirdms`, i   left them to allow backward compatibility (see e.g. https://github.com/hpc4cmb/litebirdtask/blob/92a196fbe30508d50b55ebde72e29c4c36f315d5/litebirdtask/scripts/hardware_from_imo.py#L57 ) .  