### PR TITLE
Errors on Export_focalplane

### DIFF
--- a/litebirdtask/hardware.py
+++ b/litebirdtask/hardware.py
@@ -276,7 +276,7 @@ class Hardware(object):
 
         det_table = QTable(
             [
-                Column(name="name", length=n_det, dtype="S20", unit=None),
+                Column(name="name", length=n_det, dtype="S22", unit=None),
                 Column(
                     name="quat",
                     length=n_det,
@@ -293,7 +293,7 @@ class Hardware(object):
                     name="psd_net",
                     length=n_det,
                     dtype=np.float64,
-                    unit=(u.K * np.sqrt(1.0 * u.second)),
+                    unit=(u.uK * np.sqrt(1.0 * u.second)),
                 ),
                 Column(name="bandcenter", length=n_det, dtype=np.float64, unit=u.GHz),
                 Column(name="bandwidth", length=n_det, dtype=np.float64, unit=u.GHz),

--- a/litebirdtask/hardware.py
+++ b/litebirdtask/hardware.py
@@ -342,7 +342,7 @@ class Hardware(object):
             det_table["psd_fmin"][idet] = bprops["fmin"] * 0.001 * u.Hz
             det_table["psd_fknee"][idet] = bprops["fknee"] * 0.001 * u.Hz
             det_table["psd_alpha"][idet] = bprops["alpha"]
-            det_table["psd_net"][idet] = bprops["NET"] * (u.K * np.sqrt(1.0 * u.second))
+            det_table["psd_net"][idet] = bprops["NET"] * (u.uK * np.sqrt(1.0 * u.second))
 
         if len(rate_check) > 1:
             msg = "Hardware instance contains detectors with different"

--- a/litebirdtask/hardware.py
+++ b/litebirdtask/hardware.py
@@ -276,7 +276,7 @@ class Hardware(object):
 
         det_table = QTable(
             [
-                Column(name="name", length=n_det, dtype="S16", unit=None),
+                Column(name="name", length=n_det, dtype="S20", unit=None),
                 Column(
                     name="quat",
                     length=n_det,
@@ -305,7 +305,7 @@ class Hardware(object):
                 Column(name="pol", length=n_det, dtype="S2", unit=None),
                 Column(name="handed", length=n_det, dtype="S2", unit=None),
                 Column(name="orient", length=n_det, dtype="S2", unit=None),
-                Column(name="uid", length=n_det, dtype=np.uint64, unit=None),
+                Column(name="uid", length=n_det, dtype="S37", unit=None),
             ]
         )
 

--- a/litebirdtask/hardware.py
+++ b/litebirdtask/hardware.py
@@ -286,8 +286,8 @@ class Hardware(object):
                 ),
                 Column(name="pol_leakage", length=n_det, dtype=np.float64, unit=None),
                 Column(name="fwhm", length=n_det, dtype=np.float64, unit=u.arcmin),
-                Column(name="psd_fmin", length=n_det, dtype=np.float64, unit=u.Hz),
-                Column(name="psd_fknee", length=n_det, dtype=np.float64, unit=u.Hz),
+                Column(name="psd_fmin", length=n_det, dtype=np.float64, unit=u.mHz),
+                Column(name="psd_fknee", length=n_det, dtype=np.float64, unit=u.mHz),
                 Column(name="psd_alpha", length=n_det, dtype=np.float64, unit=None),
                 Column(
                     name="psd_net",

--- a/litebirdtask/scripts/hardware_from_imo.py
+++ b/litebirdtask/scripts/hardware_from_imo.py
@@ -1,14 +1,18 @@
 # Copyright (c) 2015-2021 LiteBIRD Collaboration.
 # Full license can be found in the top level "LICENSE" file.
 """
-Plot a hardware model.
+Exporting a hardware model from LB IMO to be compatible with toast hardware.
 """
 
 import argparse
 import json
 import numpy as np
 import toml
+from litebirdms import __version__ as lbms_version
 
+from litebirdtask import __version__ as lbt_version
+
+from toast import __version__ as toast_version
 
 #the following dictionaries are kept from the scripts in litebirdms. The quantities are hardcoded  allow backward compatibility, with previous IMO files.
 
@@ -153,6 +157,7 @@ def main():
             "wafers": instrument_dic["wafers"],
             "platescale": instrument_dic["platescale_deg_mm"],
             "waferspace": instrument_dic["waferspace_mm"],
+            "samplerate":  instrument_dic['sampling_rate_hz']
         }
         newhw["pixels"][det_dic["pixtype"]] = {
             "bands": pbd[det_dic["pixtype"]],
@@ -188,6 +193,11 @@ def main():
             "orient": det_dic["orient"],
             "quat": det_dic["quat"],
             "UID": data["data_files"][i]["uuid"],
+        }
+        newhw["software"] = {
+        "litebirdms": lbms_version,
+        "litebirdtask": lbt_version,
+        "toast": toast_version,
         }
         if i - iold == channel_dic["number_of_detectors"]:
             print(

--- a/litebirdtask/scripts/hardware_from_imo.py
+++ b/litebirdtask/scripts/hardware_from_imo.py
@@ -179,7 +179,7 @@ def main():
             "NET": channel_dic["net_detector_ukrts"],
             "fwhm": channel_dic["fwhm_arcmin"],
             "fknee": channel_dic["fknee_mhz"],
-            "fmin": channel_dic["fmin_hz"],
+            "fmin": channel_dic["fmin_hz"]*1e3, ## toast expects fknee and fmin to have the same units 
             "alpha": channel_dic["alpha"],
         }
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
             "lbt_hardware_trim = litebirdtask.scripts.hardware_trim:main",
             "lbt_hardware_info = litebirdtask.scripts.hardware_info:main",
             "lbt_export_focalplane = litebirdtask.scripts.export_focalplane:main",
+            "lbt_hardware_from_imo =litebirdtask.scripts.hardware_from_imo:main"
         ]
     },
     license="BSD",


### PR DESCRIPTION
 With this PR,  i make sure that the hardware dictionary from the IMO see #6  is interfaced properly w/ the routine `export_focalplane` into hdf5 file. changes listed below  :

- include versions from `toast `, `litebirdtask` and `litebirdms` in the hardware *.toml file 
- include `samplerate` entry which was actually missed 
- change data types to longer strings for the `uid` and `name` entries
- include the script for `hardware_from_imo.py` in `setup.py` 